### PR TITLE
Avoid fetching non-parametric fields

### DIFF
--- a/webapp/core/src/main/public/static/js/find/app/page/search/service-view.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/service-view.js
@@ -450,7 +450,7 @@ define([
         fetchParametricCollection: function () {
             this.parametricCollection.reset();
 
-            const fieldNames = this.parametricFieldsCollection.pluck('id');
+            const fieldNames = _.pluck(this.parametricFieldsCollection.where({type: 'Parametric'}), 'id');
 
             if (fieldNames.length > 0 && this.queryModel.get('indexes').length !== 0) {
                 this.parametricCollection.fetch({


### PR DESCRIPTION
The parametricFieldsCollection now contains non-parametric fields, e.g. NumericDate and Numeric. Fetching numeric fields with parametricgetvalues seems to try and fetch every possible value; which takes a really long time or fails in a timeout when there's lots of distinct values esp. latitude and longitude fields. NumericDate has its own mini-chart UI, so doesn't seem to need it. 