### PR TITLE
[FIND-1153] Titles on hover when the dashboard map is exported, fixes for Leaflet upgrade

### DIFF
--- a/webapp/core/src/main/public/static/js/find/app/page/search/results/map-view.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/results/map-view.js
@@ -259,7 +259,7 @@ define([
                 }
             });
 
-            const $objs = $mapEl.find('.leaflet-objects-pane').addClass('hide');
+            const $objs = $mapEl.find('.leaflet-objects-pane, .leaflet-marker-pane, .leaflet-shadow-pane').addClass('hide');
 
             html2canvas($mapEl, {
                 // This seems to avoid issues with IE11 only rendering a small portion of the map the size of the window

--- a/webapp/core/src/main/public/static/js/find/app/page/search/results/map-view.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/results/map-view.js
@@ -232,9 +232,14 @@ define([
                                 color = leafletMarkerColorMap[match[1]]
                             }
 
-                            const popup = layer.getPopup();
-                            if (popup && popup._content) {
-                                text = $(popup._content).find('.map-popup-title').text()
+                            if (layer.options.title) {
+                                text = layer.options.title
+                            }
+                            else {
+                                const popup = layer.getPopup();
+                                if (popup && popup._content) {
+                                    text = $(popup._content).find('.map-popup-title').text()
+                                }
                             }
                         }
 

--- a/webapp/core/src/main/public/static/js/leaflet.notransform/leaflet.notransform.js
+++ b/webapp/core/src/main/public/static/js/leaflet.notransform/leaflet.notransform.js
@@ -1,7 +1,6 @@
 define([], function () {
     // Disables 3d transforms on leaflet, since they interfere with proper operation of html2canvas in Firefox/IE11
     // which can be observed by zooming in on the map, panning, then exporting the map as a PPTX
-    if (!/Chrome/.test(navigator.userAgent)) {
-        window.L_DISABLE_3D = true;
-    }
+    // After upgrading from Leaflet 0.7.7 to 1.0.3 ; Chrome also needs this flag.
+    window.L_DISABLE_3D = true;
 });


### PR DESCRIPTION
Adds titles on hover when the dashboard map is exported (the dashboard map uses a title attribute instead of a popup for its text). 

Also fixes the exported map position being wrong in Chrome; and the marker tokens and shadows being visible on the map (both are regressions due to Leaflet changes after being upgraded to 0.7.7 from 1.0.3 ).