### PR TITLE
[FIND-1008] Variable height topic map widget

### DIFF
--- a/webapp/core/src/main/less/app-include.less
+++ b/webapp/core/src/main/less/app-include.less
@@ -262,6 +262,10 @@ body {
   width: @100percent;
 }
 
+.full-height {
+  height: @100percent;
+}
+
 .full-height-viewport {
   height: @100vh;
 }
@@ -2600,19 +2604,19 @@ h4.similar-dates-message {
 }
 
 @media @smHeightScreen {
-  .entity-topic-map {
+  .entity-topic-map:not(.full-height) {
     height: @custom4;
   }
 }
 
 @media @mHeightScreen {
-  .entity-topic-map {
+  .entity-topic-map:not(.full-height) {
     height: 500px;
   }
 }
 
 @media @lgHeightScreen {
-  .entity-topic-map {
+  .entity-topic-map:not(.full-height) {
     height: @lgHeightScreenTopicMapHeight;
   }
 }

--- a/webapp/core/src/main/less/app-include.less
+++ b/webapp/core/src/main/less/app-include.less
@@ -1164,6 +1164,7 @@ audio.preview-media-player {
 
 .entity-topic-map {
   width: @100percent;
+  height: @100percent;
 }
 
 @hpeThumbBackground: @hpegreen;
@@ -2604,19 +2605,19 @@ h4.similar-dates-message {
 }
 
 @media @smHeightScreen {
-  .entity-topic-map:not(.full-height) {
+  .entity-topic-map.fixed-height {
     height: @custom4;
   }
 }
 
 @media @mHeightScreen {
-  .entity-topic-map:not(.full-height) {
+  .entity-topic-map.fixed-height {
     height: 500px;
   }
 }
 
 @media @lgHeightScreen {
-  .entity-topic-map:not(.full-height) {
+  .entity-topic-map.fixed-height {
     height: @lgHeightScreenTopicMapHeight;
   }
 }

--- a/webapp/core/src/main/public/static/js/find/app/page/search/results/entity-topic-map-view.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/results/entity-topic-map-view.js
@@ -79,7 +79,7 @@ define([
             this.queryModel = options.queryModel;
             this.type = options.type;
             this.showSlider = _.isUndefined(options.showSlider) || options.showSlider;
-            this.fullHeight = options.fullHeight;
+            this.fixedHeight = _.isUndefined(options.fixedHeight) || options.fixedHeight;
 
             this.topicMap = new TopicMapView({
                 clickHandler: options.clickHandler
@@ -135,7 +135,7 @@ define([
                 i18n: i18n,
                 loadingHtml: loadingHtml,
                 showSlider: this.showSlider,
-                fullHeight: this.fullHeight,
+                fixedHeight: this.fixedHeight,
                 min: 50,
                 max: configuration().topicMapMaxResults,
                 step: 1

--- a/webapp/core/src/main/public/static/js/find/app/page/search/results/entity-topic-map-view.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/results/entity-topic-map-view.js
@@ -79,6 +79,7 @@ define([
             this.queryModel = options.queryModel;
             this.type = options.type;
             this.showSlider = _.isUndefined(options.showSlider) || options.showSlider;
+            this.fullHeight = options.fullHeight;
 
             this.topicMap = new TopicMapView({
                 clickHandler: options.clickHandler
@@ -134,6 +135,7 @@ define([
                 i18n: i18n,
                 loadingHtml: loadingHtml,
                 showSlider: this.showSlider,
+                fullHeight: this.fullHeight,
                 min: 50,
                 max: configuration().topicMapMaxResults,
                 step: 1

--- a/webapp/core/src/main/public/static/js/find/templates/app/page/search/results/entity-topic-map-view.html
+++ b/webapp/core/src/main/public/static/js/find/templates/app/page/search/results/entity-topic-map-view.html
@@ -1,4 +1,5 @@
-<div class="col-md-12">
+<% var fullHeightClass = fullHeight ? 'full-height': '' %>
+<div class="col-md-12 <%- fullHeightClass %>">
     <% if (showSlider) { %>
         <div class="flex-row m-b-sm">
             <div class="m-r-lg flex-row slider-block">
@@ -23,5 +24,5 @@
     <div class="entity-topic-map-loading m-t-lg">
         <%= loadingHtml %>
     </div>
-    <div class="entity-topic-map"></div>
+    <div class="entity-topic-map <%- fullHeightClass %>"></div>
 </div>

--- a/webapp/core/src/main/public/static/js/find/templates/app/page/search/results/entity-topic-map-view.html
+++ b/webapp/core/src/main/public/static/js/find/templates/app/page/search/results/entity-topic-map-view.html
@@ -1,5 +1,4 @@
-<% var fullHeightClass = fullHeight ? 'full-height': '' %>
-<div class="col-md-12 <%- fullHeightClass %>">
+<div class="col-md-12 <%- fixedHeight ? '': 'full-height' %>">
     <% if (showSlider) { %>
         <div class="flex-row m-b-sm">
             <div class="m-r-lg flex-row slider-block">
@@ -24,5 +23,5 @@
     <div class="entity-topic-map-loading m-t-lg">
         <%= loadingHtml %>
     </div>
-    <div class="entity-topic-map <%- fullHeightClass %>"></div>
+    <div class="entity-topic-map <%- fixedHeight ? 'fixed-height': '' %>"></div>
 </div>

--- a/webapp/idol/src/main/public/static/js/find/idol/app/page/dashboard/widgets/topic-map-widget.js
+++ b/webapp/idol/src/main/public/static/js/find/idol/app/page/dashboard/widgets/topic-map-widget.js
@@ -25,7 +25,7 @@ define([
                 queryModel: this.queryModel,
                 queryState: this.queryModel.queryState,
                 showSlider: false,
-                fullHeight: true,
+                fixedHeight: false,
                 type: 'QUERY'
             });
 

--- a/webapp/idol/src/main/public/static/js/find/idol/app/page/dashboard/widgets/topic-map-widget.js
+++ b/webapp/idol/src/main/public/static/js/find/idol/app/page/dashboard/widgets/topic-map-widget.js
@@ -25,6 +25,7 @@ define([
                 queryModel: this.queryModel,
                 queryState: this.queryModel.queryState,
                 showSlider: false,
+                fullHeight: true,
                 type: 'QUERY'
             });
 


### PR DESCRIPTION
The topic map widget takes 100% of its widget height; instead of being a hardcoded height dependent on the screen resolution. Works in IE11, Firefox, Chrome. 