### PR TITLE
Fix topicmap cluster grouping

### DIFF
--- a/webapp/core/src/main/public/static/js/find/app/model/entity-collection.js
+++ b/webapp/core/src/main/public/static/js/find/app/model/entity-collection.js
@@ -71,7 +71,7 @@ define([
         },
 
         processDataForTopicMap: function() {
-            return this.chain().groupBy('cluster')
+            return _.chain(this.groupBy('cluster'))
             // Order the concepts in each cluster
                 .map(function(cluster) {
                     return _.sortBy(cluster, function(model) {


### PR DESCRIPTION
A typo in the refactoring in 080156d57c640325905993e3dcf68c5d9745d663 accidentally changes the topicmap such that all the lower-level clusters are being shown in the same block:
![image](https://cloud.githubusercontent.com/assets/7871081/25284048/c0a003c0-26ad-11e7-96b5-553095b78384.png)
this groups them by clusters again
![image](https://cloud.githubusercontent.com/assets/7871081/25284072/cfcdf3f2-26ad-11e7-8786-d4818e946a17.png)
