### PR TITLE
Fix rendering of docs without dates; and HOD startup

### DIFF
--- a/webapp/core/src/main/public/static/js/find/app/page/search/document-renderer.js
+++ b/webapp/core/src/main/public/static/js/find/app/page/search/document-renderer.js
@@ -66,7 +66,7 @@ define([
         return {
             reference: model.get('reference'),
             title: model.get('title'),
-            date: date.format('LLLL'),
+            date: date && date.format('LLLL'),
             database: model.get('index'),
             promotionName: model.get('promotionName'),
             similarDocumentsUrl: vent.suggestUrlForDocument(model),
@@ -74,7 +74,7 @@ define([
             url: url ? urlManipulator.addSpecialUrlPrefix(model.get('contentType'), url) : null,
             icon: 'icomoon-file-' + getContentTypeClass(model),
             thumbnailSrc: thumbnailSrc,
-            age: date.fromNow(),
+            age: date && date.fromNow(),
             fields: model.get('fields').map(_.partial(_.pick, _, ['id', 'displayName', 'advanced', 'values']))
         };
     }

--- a/webapp/hod/src/main/java/com/hp/autonomy/frontend/find/hod/web/HodFindController.java
+++ b/webapp/hod/src/main/java/com/hp/autonomy/frontend/find/hod/web/HodFindController.java
@@ -7,6 +7,7 @@ package com.hp.autonomy.frontend.find.hod.web;
 
 import com.hp.autonomy.frontend.configuration.ConfigService;
 import com.hp.autonomy.frontend.configuration.authentication.AuthenticationConfig;
+import com.hp.autonomy.frontend.find.core.configuration.TemplatesConfig;
 import com.hp.autonomy.frontend.find.core.export.service.MetadataNode;
 import com.hp.autonomy.frontend.find.core.web.ControllerUtils;
 import com.hp.autonomy.frontend.find.core.web.FindController;
@@ -16,32 +17,41 @@ import com.hp.autonomy.frontend.find.hod.configuration.HodFindConfig.HodFindConf
 import com.hp.autonomy.frontend.find.hod.export.service.HodMetadataNode;
 import com.hp.autonomy.searchcomponents.core.fields.FieldDisplayNameGenerator;
 import com.hpe.bigdata.frontend.spring.authentication.AuthenticationInformationRetriever;
+import java.util.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 @Controller
 public class HodFindController extends FindController<HodFindConfig, HodFindConfigBuilder> {
+
+    private final ConfigService<TemplatesConfig> templatesConfig;
+
     @SuppressWarnings("TypeMayBeWeakened")
     @Autowired
     public HodFindController(final ControllerUtils controllerUtils,
                              final AuthenticationInformationRetriever<?, ? extends Principal> authenticationInformationRetriever,
                              final ConfigService<? extends AuthenticationConfig<?>> authenticationConfigService,
                              final ConfigService<HodFindConfig> configService,
+                             final ConfigService<TemplatesConfig> templatesConfig,
                              final FieldDisplayNameGenerator fieldDisplayNameGenerator) {
         super(controllerUtils, authenticationInformationRetriever, authenticationConfigService, configService, fieldDisplayNameGenerator);
+        this.templatesConfig = templatesConfig;
     }
 
     @Override
     protected Map<String, Object> getPublicConfig() {
         final HodFindConfig config = configService.getConfig();
 
-        return Collections.singletonMap(MvcConstants.PUBLIC_INDEXES_ENABLED.value(), config.getHod().getPublicIndexesEnabled());
+        final Map<String, Object> publicConfig = new HashMap<>();
+        publicConfig.put(MvcConstants.PUBLIC_INDEXES_ENABLED.value(), config.getHod().getPublicIndexesEnabled());
+        publicConfig.put(MvcConstants.TEMPLATES_CONFIG.value(), templatesConfig.getConfig());
+
+        return publicConfig;
     }
 
     @Override

--- a/webapp/hod/src/main/resources/defaultHodConfigFile.json
+++ b/webapp/hod/src/main/resources/defaultHodConfigFile.json
@@ -63,6 +63,10 @@
     },
     "uiCustomization": {
         "options": {
+            "enableDashboards": {
+                "user": false,
+                "bi": true
+            },
             "enableMetaFilter": {
                 "user": false,
                 "bi": true
@@ -72,6 +76,10 @@
                 "bi": false
             },
             "enableSavedSearch": {
+                "user": false,
+                "bi": true
+            },
+            "enableSideBar": {
                 "user": false,
                 "bi": true
             },


### PR DESCRIPTION
If a document doesn't have a date, it was throwing a JS exception when it tried to format the date.
Also adds some fixes so that HOD mode starts up. 